### PR TITLE
Adds grid movement

### DIFF
--- a/battle-map-explorer-dev.js
+++ b/battle-map-explorer-dev.js
@@ -49,6 +49,8 @@ BattleMapExplorer.run = function(image, position, polygons, doors) {
 	var hammer = new Hammer(document.getElementById("canvas"));
 	hammer.get('pan').set({ direction: Hammer.DIRECTION_ALL });
 
+	var gridinc = 25;
+	
 	var img1 = new Image();
 	var img1_loaded = false;
 	img1.onload = function(){
@@ -114,7 +116,26 @@ BattleMapExplorer.run = function(image, position, polygons, doors) {
 			update_needed = true;
 		} else if (e.keyCode == 32) {
 			// Press "space" to get the current position.
-			console.log("[" + observer_x + "," + observer_y + "]");
+			console.log("[" + observer_x + "," + observer_y + "],");
+		} else if (e.keyCode == 96) {
+			//Change grid increment (gridinc)
+			gridinc = parseInt(prompt("Enter the desired increment:", gridinc));
+		} else if (e.keyCode == 104) {
+			//up
+			move(observer_x - 0, observer_y - gridinc);
+			update_needed = true;
+		} else if (e.keyCode == 100) {
+			//left
+			move(observer_x - gridinc, observer_y - 0);
+			update_needed = true;
+		} else if (e.keyCode == 102) {
+			//right
+			move(observer_x + gridinc, observer_y - 0);
+			update_needed = true;
+		} else if (e.keyCode == 98) {
+			//down
+			move(observer_x - 0, observer_y + gridinc);
+			update_needed = true;
 		}
 	}
 


### PR DESCRIPTION
Allows the use of the numpad to move in user-specified increments. Intended for use in marking polygon coordinates with 'space'.

Num0 will prompt the user for a new increment value (default 25 pixels).

Also added a ',' to the coordinate output in the console, to make it easy to paste the output into the map HTML file. (Easier to delete the last one than to add commas between the others.)
